### PR TITLE
Remove unneeded configuration in buildPlugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(platforms: ['linux'], jdkVersions: [8], findbugs: [archive: true, unstableTotalAll: '0'], checkstyle: [run: true, archive: true])
+buildPlugin(platforms: ['linux'], jdkVersions: [8])


### PR DESCRIPTION
Spotbugs and checkstyle are being enabled by default in https://github.com/jenkins-infra/pipeline-library/pull/121