### PR TITLE
Fix default listSize

### DIFF
--- a/src/main/java/com/syhuang/hudson/plugins/listgitbranchesparameter/ListGitBranchesParameterDefinition.java
+++ b/src/main/java/com/syhuang/hudson/plugins/listgitbranchesparameter/ListGitBranchesParameterDefinition.java
@@ -66,7 +66,7 @@ public class ListGitBranchesParameterDefinition extends ParameterDefinition impl
     @DataBoundConstructor
     public ListGitBranchesParameterDefinition(String name, String description, String remoteURL, String credentialsId, String defaultValue,
                                               SortMode sortMode, SelectedValue selectedValue, Boolean quickFilterEnabled,
-                                              String type, String tagFilter, String branchFilter) {
+                                              String type, String tagFilter, String branchFilter, String listSize) {
         super(name, description);
         this.remoteURL = remoteURL;
         this.credentialsId = credentialsId;
@@ -75,7 +75,7 @@ public class ListGitBranchesParameterDefinition extends ParameterDefinition impl
         this.sortMode = sortMode;
         this.selectedValue = selectedValue;
         this.quickFilterEnabled = quickFilterEnabled;
-        this.listSize = DEFAULT_LIST_SIZE;
+        this.listSize = listSize;
 
         setType(type);
         setTagFilter(tagFilter);


### PR DESCRIPTION
Corrected the default listSize to prevent it from always being overwritten by the DEFAULT_LIST_SIZE as noted in the following issues:
- Fixes JENKINS-66726
- Fixes JENKINS-66719

Code changes:
- Added "String listSize" to the constructor
- Changed the initial set from "this.listSize = DEFAULT_LIST_SIZE" to "this.listSize = listSize"
