### PR TITLE
Update parent pom, minimum jenkins to 2.346.3 and dependency cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <artifactId>plugin</artifactId>
         <!-- Baseline Jenkins version you use to build and test the plugin. Users
             must have this version or newer to run. -->
-        <version>2.26</version>
+        <version>4.51</version>
     </parent>
 
     <groupId>org.jenkins-ci.plugins</groupId>
@@ -34,8 +34,7 @@
     </repositories>
 
     <properties>
-        <java.level>7</java.level>
-        <jenkins.version>1.651.3</jenkins.version>
+        <jenkins.version>2.346.3</jenkins.version>
     </properties>
 
     <developers>
@@ -63,11 +62,22 @@
         </pluginRepository>
     </pluginRepositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.346.x</artifactId>
+                <version>1763.v092b_8980a_f5e</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>3.9.3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -81,38 +91,21 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
-        </dependency>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.9.2</version>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-lang3-api</artifactId>
+            <version>3.12.0-36.vd97de6465d5b_</version>
         </dependency>
         <!-- Test scope -->
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>1.8.5</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-aggregator</artifactId>
-            <version>2.5</version>
+            <version>2.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>template-project</artifactId>
             <version>1.5.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>multiple-scms</artifactId>
-            <version>0.6</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/syhuang/hudson/plugins/listgitbranchesparameter/ListGitBranchesParameterDefinition.java
+++ b/src/main/java/com/syhuang/hudson/plugins/listgitbranchesparameter/ListGitBranchesParameterDefinition.java
@@ -162,7 +162,7 @@ public class ListGitBranchesParameterDefinition extends ParameterDefinition impl
 
     private Job getParentJob() {
         Job context = null;
-        List<Job> jobs = Objects.requireNonNull(Jenkins.getInstance()).getAllItems(Job.class);
+        List<Job> jobs = Jenkins.get().getAllItems(Job.class);
 
         for (Job job : jobs) {
             if (!(job instanceof TopLevelItem)) continue;
@@ -374,7 +374,14 @@ public class ListGitBranchesParameterDefinition extends ParameterDefinition impl
 
 
     private GitClient createGitClient(Job job) throws IOException, InterruptedException {
-        EnvVars env = Objects.requireNonNull(Objects.requireNonNull(Jenkins.getInstance()).toComputer()).getEnvironment();
+        final Computer computer = Jenkins.get().toComputer();
+        EnvVars env;
+        if (computer != null) {
+            env = computer.getEnvironment();
+        } else {
+          env = null;
+        }
+
         Git git = Git.with(TaskListener.NULL, env);
 
         GitClient c = git.getClient();

--- a/src/main/java/com/syhuang/hudson/plugins/listgitbranchesparameter/ListGitBranchesParameterRebuild.java
+++ b/src/main/java/com/syhuang/hudson/plugins/listgitbranchesparameter/ListGitBranchesParameterRebuild.java
@@ -5,7 +5,7 @@ import com.sonyericsson.rebuild.RebuildParameterProvider;
 import hudson.Extension;
 import hudson.model.ParameterValue;
 
-@Extension
+@Extension(optional = true)
 public class ListGitBranchesParameterRebuild extends RebuildParameterProvider {
     @Override
     public RebuildParameterPage getRebuildPage(ParameterValue parameterValue) {


### PR DESCRIPTION
Update parent pom, including:
* Set minimum Jenkins to 2.346.3
* Introduce dependency management to ease updating dependencies
* Remove dreprecated java level (the used parent pom still supports Java 8)
* Removed unused dependencies
* Replaced commons-lang3 dependency with api plugin (mainly to get a smaller plugin)
* Set the Extension to optional because the dependency is optional [Jenkins Docu](https://www.jenkins.io/doc/developer/plugin-development/optional-dependencies/)
* Fixed spotbugs issue
* Use `Jenkins.get()` instead of deprecated `Jenkins.getInstance()`

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
