### PR TITLE
Upgrade from jQuery 1.x to jQuery 3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,9 +88,8 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>jquery</artifactId>
-            <version>1.12.4-1</version>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>jquery3-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sonyericsson.hudson.plugins.rebuild</groupId>

--- a/src/main/resources/com/syhuang/hudson/plugins/listgitbranchesparameter/ListGitBranchesParameterDefinition/index.jelly
+++ b/src/main/resources/com/syhuang/hudson/plugins/listgitbranchesparameter/ListGitBranchesParameterDefinition/index.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
          xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
          xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-    <st:adjunct includes="org.kohsuke.stapler.jquery" />
+    <st:adjunct includes="io.jenkins.plugins.jquery3" />
     <st:adjunct includes="com.syhuang.hudson.plugins.listgitbranchesparameter.script" />
     <j:set var="divId" value="${it.divUUID}" scope="parent" />
     <j:set var="escapeEntryTitleAndDescription" value="false"/>


### PR DESCRIPTION
We are about to deprecate the jQuery 1.x Jenkins library plugin, since it is not CSP compliant. In preparation for this deprecation, migrate from jQuery 1.x to 3.x.

To test this, I manually created a job with a List Git Branches Parameter without the jQuery 1.x plugin and confirmed it was broken before this PR and fixed after this PR.

@huangsuoyuan Can this please be merged and released?