### PR TITLE
Require Jenkins 2.479.1 and Jakarta EE 9

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,11 @@
-buildPlugin(useContainerAgent: true, configurations: [
-  [platform: 'linux', jdk: 21],
-  [platform: 'windows', jdk: 17],
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
+buildPlugin(
+  forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.88</version>
+        <version>5.7</version>
         <relativePath />
     </parent>
 
@@ -21,7 +21,7 @@
     <licenses>
         <license>
             <name>MIT License</name>
-            <url>http://opensource.org/licenses/MIT</url>
+            <url>https://opensource.org/licenses/MIT</url>
         </license>
     </licenses>
 
@@ -36,8 +36,8 @@
         <revision>0.0.14</revision>
         <changelist>-SNAPSHOT</changelist>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.440</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+        <jenkins.baseline>2.479</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
 
@@ -71,7 +71,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>3435.v238d66a_043fb_</version>
+                <version>4136.vca_c3202a_7fd1</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/java/com/syhuang/hudson/plugins/listgitbranchesparameter/ListGitBranchesParameterDefinition.java
+++ b/src/main/java/com/syhuang/hudson/plugins/listgitbranchesparameter/ListGitBranchesParameterDefinition.java
@@ -29,7 +29,7 @@ import org.jvnet.localizer.ResourceBundleHolder;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -83,7 +83,7 @@ public class ListGitBranchesParameterDefinition extends ParameterDefinition impl
     }
 
     @Override
-    public ParameterValue createValue(StaplerRequest req, JSONObject jo) {
+    public ParameterValue createValue(StaplerRequest2 req, JSONObject jo) {
         Object value = jo.get("value");
         StringBuilder strValue = new StringBuilder();
         if (value instanceof String) {
@@ -106,7 +106,7 @@ public class ListGitBranchesParameterDefinition extends ParameterDefinition impl
     }
 
     @Override
-    public ParameterValue createValue(StaplerRequest req) {
+    public ParameterValue createValue(StaplerRequest2 req) {
         String value[] = req.getParameterValues(getName());
         if (value == null || value.length == 0 || StringUtils.isBlank(value[0])) {
             return this.getDefaultParameterValue();
@@ -461,7 +461,7 @@ public class ListGitBranchesParameterDefinition extends ParameterDefinition impl
                     );
         }
 
-        public FormValidation doCheckRemoteURL(StaplerRequest req, @AncestorInPath Item context, @QueryParameter String value) {
+        public FormValidation doCheckRemoteURL(StaplerRequest2 req, @AncestorInPath Item context, @QueryParameter String value) {
             String url = Util.fixEmptyAndTrim(value);
 
             if (url == null) {

--- a/src/main/java/com/syhuang/hudson/plugins/listgitbranchesparameter/ListGitBranchesParameterDefinition.java
+++ b/src/main/java/com/syhuang/hudson/plugins/listgitbranchesparameter/ListGitBranchesParameterDefinition.java
@@ -7,6 +7,7 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.*;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Util;
@@ -67,7 +68,7 @@ public class ListGitBranchesParameterDefinition extends ParameterDefinition impl
     public ListGitBranchesParameterDefinition(String name, String description, String remoteURL, String credentialsId, String defaultValue,
                                               SortMode sortMode, SelectedValue selectedValue, Boolean quickFilterEnabled,
                                               String type, String tagFilter, String branchFilter, String listSize) {
-        super(name, description);
+        super(name);
         this.remoteURL = remoteURL;
         this.credentialsId = credentialsId;
         this.defaultValue = defaultValue;
@@ -77,6 +78,7 @@ public class ListGitBranchesParameterDefinition extends ParameterDefinition impl
         this.quickFilterEnabled = quickFilterEnabled;
         this.listSize = listSize;
 
+        setDescription(description);
         setType(type);
         setTagFilter(tagFilter);
         setBranchFilter(branchFilter);
@@ -88,9 +90,8 @@ public class ListGitBranchesParameterDefinition extends ParameterDefinition impl
         StringBuilder strValue = new StringBuilder();
         if (value instanceof String) {
             strValue.append(value);
-        } else if (value instanceof JSONArray) {
-            JSONArray jsonValues = (JSONArray) value;
-            for (int i = 0; i < jsonValues.size(); i++) {
+        } else if (value instanceof JSONArray jsonValues) {
+	        for (int i = 0; i < jsonValues.size(); i++) {
                 strValue.append(jsonValues.getString(i));
                 if (i < jsonValues.size() - 1) {
                     strValue.append(",");
@@ -98,7 +99,7 @@ public class ListGitBranchesParameterDefinition extends ParameterDefinition impl
             }
         }
 
-        if (strValue.length() == 0) {
+        if (strValue.isEmpty()) {
             strValue.append(defaultValue);
         }
 
@@ -107,7 +108,7 @@ public class ListGitBranchesParameterDefinition extends ParameterDefinition impl
 
     @Override
     public ParameterValue createValue(StaplerRequest2 req) {
-        String value[] = req.getParameterValues(getName());
+        String[] value = req.getParameterValues(getName());
         if (value == null || value.length == 0 || StringUtils.isBlank(value[0])) {
             return this.getDefaultParameterValue();
         } else {
@@ -134,7 +135,7 @@ public class ListGitBranchesParameterDefinition extends ParameterDefinition impl
             case TOP:
                 try {
                     ListBoxModel valueItems = getDescriptor().doFillValueItems(getParentJob(), getName());
-                    if (valueItems.size() > 0) {
+                    if (!valueItems.isEmpty()) {
                         return new ListGitBranchesParameterValue(getName(), valueItems.get(0).value);
                     }
                 } catch (Exception e) {
@@ -273,7 +274,7 @@ public class ListGitBranchesParameterDefinition extends ParameterDefinition impl
         ArrayList<String> tags = new ArrayList<>(set);
 
         if (getSortMode().getIsSorting()) {
-            Collections.sort(tags, new SmartNumberStringComparator());
+            tags.sort(new SmartNumberStringComparator());
         } else {
             Collections.sort(tags);
         }
@@ -321,19 +322,17 @@ public class ListGitBranchesParameterDefinition extends ParameterDefinition impl
         Pattern branchFilterPattern = compileBranchFilterPattern();
 
         Map<String, ObjectId> branches = gitClient.getRemoteReferences(gitUrl, null, true, false);
-        Iterator<String> remoteBranchesName = branches.keySet().iterator();
-        while (remoteBranchesName.hasNext()) {
-            //String branchName = strip(remoteBranchesName.next(), remoteName);
-            String branchName = remoteBranchesName.next();
-            Matcher matcher = branchFilterPattern.matcher(branchName);
-            if (matcher.matches()) {
-                if (matcher.groupCount() == 1) {
-                    branchSet.add(matcher.group(1));
-                } else {
-                    branchSet.add(branchName);
-                }
-            }
-        }
+	    for (String branchName : branches.keySet()) {
+		    //String branchName = strip(remoteBranchesName.next(), remoteName);
+		    Matcher matcher = branchFilterPattern.matcher(branchName);
+		    if (matcher.matches()) {
+			    if (matcher.groupCount() == 1) {
+				    branchSet.add(matcher.group(1));
+			    } else {
+				    branchSet.add(branchName);
+			    }
+		    }
+	    }
         return branchSet;
     }
 
@@ -344,7 +343,7 @@ public class ListGitBranchesParameterDefinition extends ParameterDefinition impl
 
     @Nonnull
     private Map<String, String> generateContents(Job job) throws IOException, InterruptedException {
-        Map<String, String> paramList = new LinkedHashMap<String, String>();
+        Map<String, String> paramList = new LinkedHashMap<>();
         GitClient gitClient = createGitClient(job);
         try {
             if (isTagType()) {
@@ -385,8 +384,8 @@ public class ListGitBranchesParameterDefinition extends ParameterDefinition impl
         Git git = Git.with(TaskListener.NULL, env);
 
         GitClient c = git.getClient();
-        List<StandardUsernameCredentials> urlCredentials = CredentialsProvider.lookupCredentials(
-                StandardUsernameCredentials.class, job, ACL.SYSTEM, URIRequirementBuilder.fromUri(remoteURL).build()
+        List<StandardUsernameCredentials> urlCredentials = CredentialsProvider.lookupCredentialsInItem(
+                StandardUsernameCredentials.class, job, ACL.SYSTEM2, URIRequirementBuilder.fromUri(remoteURL).build()
         );
         CredentialsMatcher ucMatcher = CredentialsMatchers.withId(credentialsId);
         CredentialsMatcher idMatcher = CredentialsMatchers.allOf(ucMatcher, GitClient.CREDENTIALS_MATCHER);
@@ -412,6 +411,7 @@ public class ListGitBranchesParameterDefinition extends ParameterDefinition impl
         return branchFilterPattern;
     }
 
+    @NonNull
     @Override
     public DescriptorImpl getDescriptor() {
         return (DescriptorImpl) super.getDescriptor();
@@ -448,16 +448,16 @@ public class ListGitBranchesParameterDefinition extends ParameterDefinition impl
 
             return new StandardListBoxModel()
                     .includeEmptyValue()
-                    .withMatching(
+                    .includeMatchingAs(
+                            ACL.SYSTEM2,
+                            context,
+                            StandardCredentials.class,
+                            domainRequirements,
                             CredentialsMatchers.anyOf(
                                     CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class),
                                     CredentialsMatchers.instanceOf(StandardCertificateCredentials.class),
                                     CredentialsMatchers.instanceOf(SSHUserPrivateKey.class)
-                            ),
-                            CredentialsProvider.lookupCredentials(StandardCredentials.class,
-                                    context,
-                                    ACL.SYSTEM,
-                                    domainRequirements)
+                            )
                     );
         }
 


### PR DESCRIPTION
## Require Jenkins 2.479.1 and Jakarta EE 9

Jenkins 2.479.1 provides Jakarta EE 9, Eclipse Jetty 12, Spring Security 6, and Java 17.

* Update plugin pom and baseline
* Remove deprecations
* Use Java 17 language features
* Minor cleanup

### Testing done

`mvn clean verify`

### Submitter checklist
* [x]  Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
* [x]  Ensure that the pull request title represents the desired changelog entry
* [x]  Please describe what you did
* [x]  Link to relevant issues in GitHub or Jira
* [x]  Link to relevant pull requests, esp. upstream and downstream changes
* [x]  Ensure you have provided tests - that demonstrates feature works or fixes the issue
